### PR TITLE
Update plugin to dedupe and shrinkwrap devDependecies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The `shrinkwrap` task has the following configuration options.
 shrinkwrap: {
   dev: true, // whether the shrinkwrap dev dependencies. Defaults to false.
   dedupe: true // whether to run dedupe before shrinkwrapping.  Defaults to false.
+  prune: true // whether to run prune before deduping. Defaults to false.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,5 +25,14 @@ In your project's Gruntfile, the `shrinkwrap` task is available to use.
 You can run `grunt shrinkwrap` standalone
 Or add it to an existing task: `grunt.registerTask('test', ['clean', 'shrinkwrap']);`
 
+The `shrinkwrap` task has the following configuration options.
+
+```js
+shrinkwrap: {
+  dev: true, // whether the shrinkwrap dev dependencies. Defaults to false.
+  dedupe: true // whether to run dedupe before shrinkwrapping.  Defaults to false.
+}
+```
+
 ## Release History
 0.1.1 - First release.

--- a/tasks/shrinkwrap.js
+++ b/tasks/shrinkwrap.js
@@ -29,9 +29,17 @@ function dedupe(grunt) {
   exec(grunt, 'npm dedupe', 'dedupe failed.');
 }
 
+function prune(grunt) {
+  exec(grunt, 'npm prune', 'prune failed');
+}
+
 module.exports = function(grunt) {
   grunt.registerTask('shrinkwrap', 'Grunt task for shrinkwrapping your projects dependencies via npm shrinkwrap', function() {
     var config = grunt.config('shrinkwrap');
+
+    if (config.prune) {
+      prune(grunt);
+    }
 
     if (config.dedupe) {
       dedupe(grunt);

--- a/tasks/shrinkwrap.js
+++ b/tasks/shrinkwrap.js
@@ -19,7 +19,10 @@ function exec(grunt, cmd, errorMsg) {
 }
 
 function shrinkwrap(grunt) {
-  exec(grunt, 'npm shrinkwrap --production', 'shrinkwrapping failed.');
+  var config = grunt.config('shrinkwrap'),
+      env = config.dev ? "--dev" : "--production";
+
+  exec(grunt, 'npm shrinkwrap ' + env, 'shrinkwrapping failed.');
 }
 
 function dedupe(grunt) {

--- a/tasks/shrinkwrap.js
+++ b/tasks/shrinkwrap.js
@@ -10,14 +10,30 @@
 
 var shelljs = require('shelljs');
 
+function exec(grunt, cmd, errorMsg) {
+  var result = shelljs.exec(cmd);
+
+  if (result.code !== 0) {
+    grunt.fatal(errorMsg);
+  }
+}
+
+function shrinkwrap(grunt) {
+  exec(grunt, 'npm shrinkwrap --production', 'shrinkwrapping failed.');
+}
+
+function dedupe(grunt) {
+  exec(grunt, 'npm dedupe', 'dedupe failed.');
+}
+
 module.exports = function(grunt) {
-
   grunt.registerTask('shrinkwrap', 'Grunt task for shrinkwrapping your projects dependencies via npm shrinkwrap', function() {
-    var result = shelljs.exec('npm shrinkwrap --production');
+    var config = grunt.config('shrinkwrap');
 
-    if (result.code !== 0) {
-      grunt.fatal("shrinkwrapping failed.");
+    if (config.dedupe) {
+      dedupe(grunt);
     }
-  });
 
+    shrinkwrap(grunt);
+  });
 };

--- a/tasks/shrinkwrap.js
+++ b/tasks/shrinkwrap.js
@@ -13,7 +13,11 @@ var shelljs = require('shelljs');
 module.exports = function(grunt) {
 
   grunt.registerTask('shrinkwrap', 'Grunt task for shrinkwrapping your projects dependencies via npm shrinkwrap', function() {
-    shelljs.exec('npm shrinkwrap --production');
+    var result = shelljs.exec('npm shrinkwrap --production');
+
+    if (result.code !== 0) {
+      grunt.fatal("shrinkwrapping failed.");
+    }
   });
 
 };

--- a/test/expected/npm-shrinkwrap.json
+++ b/test/expected/npm-shrinkwrap.json
@@ -1,5 +1,0 @@
-{
-  "name": "grunt-shrinkwrap",
-  "version": "0.1.1",
-  "dependencies": {}
-}

--- a/test/shrinkwrap_test.js
+++ b/test/shrinkwrap_test.js
@@ -6,13 +6,15 @@ exports.shrinkwrap = {
   setUp: function(done) {
     done();
   },
+
   default_options: function(test) {
     test.expect(1);
 
-    var expected = grunt.file.read('test/expected/npm-shrinkwrap.json');
-    var actual = grunt.file.read('npm-shrinkwrap.json');
-
-    test.equal(actual, expected, 'should have generated an npm-shrinkwrap.json');
+    /*
+     * We don't actually care what the contents of npm-shrinkwrap.json is that's npm's job.
+     * We just care that it was generated.
+     */
+    test.ok(grunt.file.exists('npm-shrinkwrap.json'), 'should have generated an npm-shrinkwrap.json');
 
     test.done();
   }


### PR DESCRIPTION
Similar to #3 I prefer to shrinkwrap all my dependencies as I've been bitten by changes in my devDependencies rendering my build broken.

It's also a good idea to to [dedupe](https://docs.npmjs.com/cli/dedupe) your package tree before shrinkwrapping as this reduces download time/bandwidth required when installing the module's dependencies.

The new options currently default to false as not to break existing users.
